### PR TITLE
fix: align episode image with card edges

### DIFF
--- a/src/components/EpisodeCard.tsx
+++ b/src/components/EpisodeCard.tsx
@@ -89,7 +89,7 @@ export function EpisodeCard({ episode, index }: EpisodeCardProps) {
     role="article"
     aria-label={`Episodio: ${episode.title}`}
     tabIndex={0}
-    className={`group hover-lift glass-effect [border-color:var(--border)] hover:[border-color:var(--primary)] relative overflow-hidden perspective-1000 transition-all duration-700 ease-out max-w-xs mx-auto md:max-w-sm shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
+    className={`group hover-lift glass-effect [border-color:var(--border)] hover:[border-color:var(--primary)] relative overflow-hidden perspective-1000 transition-all duration-700 ease-out max-w-xs mx-auto md:max-w-sm shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 py-0 gap-0 ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
   style={{ transform: prefersReduced ? undefined : `rotateX(${tilt.rx}deg) rotateY(${tilt.ry}deg)` }}
   > 
       {/* Neural glow effect */}
@@ -104,7 +104,7 @@ export function EpisodeCard({ episode, index }: EpisodeCardProps) {
 
       {/* Episode image (if present) */}
       {episode.imageUrl && (
-        <div className="w-full aspect-square relative">
+        <div className="w-full aspect-square relative overflow-hidden">
           <img
             src={episode.imageUrl}
             alt={episode.title}
@@ -112,7 +112,7 @@ export function EpisodeCard({ episode, index }: EpisodeCardProps) {
             decoding="async"
             fetchPriority="low"
             draggable={false}
-            className="w-full h-full object-cover rounded-lg shadow-md"
+            className="w-full h-full object-cover"
           />
         </div>
       )}


### PR DESCRIPTION
# Pull Request

## Summary

Fix the episode card image spacing so the artwork reaches the card edges cleanly.

Changes:
- Remove vertical padding and gap around episode artwork
- Clip the image wrapper to the card boundaries
- Remove image-specific border radius and shadow
- Preserve the existing card layout, hover behavior, and responsiveness

## Screenshots

UI change verified locally.

## Checklist

- [x] Tests or manual verification performed
- [x] Screenshots updated (if UI changed)
- [ ] Documentation updated (README/ARCHITECTURE as needed)
- [ ] Lighthouse CI passes

## Screenshots

### Before

<img width="1915" height="1034" alt="image" src="https://github.com/user-attachments/assets/c65c0fe7-ef77-41fe-8c7e-f8976cf02a4a" />

### After

<img width="1915" height="1033" alt="image" src="https://github.com/user-attachments/assets/3e9180fe-b510-44b7-8532-3432641fc942" />